### PR TITLE
Allow foreign keys to be strings

### DIFF
--- a/sphinxcontrib_django/docstrings.py
+++ b/sphinxcontrib_django/docstrings.py
@@ -141,8 +141,12 @@ def _add_model_fields_as_params(app, obj, lines):
         # Add type
         if isinstance(field, models.ForeignKey):
             to = field.rel.to
-            lines.append(u':type %s: %s to :class:`~%s.%s`' % (
-            field.name, type(field).__name__, to.__module__, to.__name__))
+            if instance(to, str):
+                lines.append(u':type %s: %s to :class:`~%s`' % (
+                field.name, type(field).__name__, to))
+            else:
+                lines.append(u':type %s: %s to :class:`~%s.%s`' % (
+                field.name, type(field).__name__, to.__module__, to.__name__))
         else:
             lines.append(u':type %s: %s' % (field.name, type(field).__name__))
 

--- a/sphinxcontrib_django/docstrings.py
+++ b/sphinxcontrib_django/docstrings.py
@@ -141,7 +141,7 @@ def _add_model_fields_as_params(app, obj, lines):
         # Add type
         if isinstance(field, models.ForeignKey):
             to = field.rel.to
-            if instance(to, str):
+            if isinstance(to, str):
                 lines.append(u':type %s: %s to :class:`~%s`' % (
                 field.name, type(field).__name__, to))
             else:


### PR DESCRIPTION
Hello, awesome project! I encountered a bug when `'auth.User'` was provided as a foreign key. It's valid to have a string path as a Foreign Key, and this change just prints the string path.

I'm not sure of other places in the code that would need to be updated to handle this case. Maybe we can try to update those too?