### PR TITLE
Use the string as cls_path if the related_model is specified as a string

### DIFF
--- a/sphinxcontrib_django/docstrings.py
+++ b/sphinxcontrib_django/docstrings.py
@@ -227,7 +227,10 @@ def _improve_attribute_docs(obj, name, lines):
     elif isinstance(obj, related_descriptors.ForwardManyToOneDescriptor):
         # Display a reasonable output for forward descriptors.
         related_model = obj.field.remote_field.model
-        cls_path = "{}.{}".format(related_model.__module__, related_model.__name__)
+        if isinstance(related_model, str):
+            cls_path = related_model
+        else:
+            cls_path = "{}.{}".format(related_model.__module__, related_model.__name__)
         del lines[:]
         lines.append("**Model field:** {label}, "
                      "accesses the :class:`~{cls_path}` model.".format(
@@ -246,7 +249,10 @@ def _improve_attribute_docs(obj, name, lines):
                      ))
     elif isinstance(obj, related_descriptors.ReverseManyToOneDescriptor):
         related_model = obj.rel.related_model
-        cls_path = "{}.{}".format(related_model.__module__, related_model.__name__)
+        if isinstance(related_model, str):
+            cls_path = related_model
+        else:
+            cls_path = "{}.{}".format(related_model.__module__, related_model.__name__)
         del lines[:]
         lines.append("**Model field:** {label}, "
                      "accesses the M2M :class:`~{cls_path}` model.".format(

--- a/sphinxcontrib_django/docstrings.py
+++ b/sphinxcontrib_django/docstrings.py
@@ -235,7 +235,10 @@ def _improve_attribute_docs(obj, name, lines):
                      ))
     elif isinstance(obj, related_descriptors.ReverseOneToOneDescriptor):
         related_model = obj.related.related_model
-        cls_path = "{}.{}".format(related_model.__module__, related_model.__name__)
+        if isinstance(related_model, str):
+            cls_path = related_model
+        else:
+            cls_path = "{}.{}".format(related_model.__module__, related_model.__name__)
         del lines[:]
         lines.append("**Model field:** {label}, "
                      "accesses the :class:`~{cls_path}` model.".format(


### PR DESCRIPTION
Handle that Django related_models sometimes are strings, i.e. when using `my_field = ForeignKey('MyModel')` rather than something like,
```
from my_models import MyModel
...
    my_field = ForeignKey(MyModel)
```