### PR TITLE
Include role for models

### DIFF
--- a/sphinxcontrib_django/roles.py
+++ b/sphinxcontrib_django/roles.py
@@ -1,16 +1,32 @@
 """Adding extra roles for documentation writing."""
 import logging
 
+from django.apps import apps
+from sphinx.domains.python import PyXRefRole
 from sphinx.errors import ExtensionError
 
 logger = logging.getLogger(__name__)
+
+
+class ModelRole(PyXRefRole):
+    """Expose Django models as roles for Sphinx."""
+
+    def process_link(self, env, refnode, has_explicit_title, title, target):
+        """Get full python path to model."""
+        model = apps.get_model(target)
+        target = ".".join([model.__module__, model.__qualname__])
+
+        return super().process_link(
+            env, refnode, has_explicit_title, title, target
+        )
 
 
 def setup(app):
     """Allow this module to be used as Sphinx extension.
 
     This is also called from the top-level ``__init__.py``.
-    It adds the rules to allow :django:setting:`SITE_ID` to work.
+    It adds the rules to allow :django:setting:`SITE_ID` and
+    :py:model:`app.Model` to work.
 
     :type app: sphinx.application.Sphinx
     """
@@ -21,4 +37,9 @@ def setup(app):
             indextemplate="pair: %s; setting",
         )
     except ExtensionError as e:
-        logger.warning("Unable to register :django:setting:`..`: " + str(e))
+        logger.warning("Unable to register :django:setting:`..`: %(e)s", {e: str(e)})
+
+    try:
+        app.add_role_to_domain("py", "class", ModelRole())
+    except ExtensionError as e:
+        logger.warning("Unable to register :py:model:`..`: %(e)s", {e: str(e)})


### PR DESCRIPTION
The Django admin documentation generator has a [role to link to models]( https://docs.djangoproject.com/en/2.2/ref/contrib/admin/admindocs/#model-reference) `` :model:`app_label.ModelName` `` that links to the documentation page generate by Django.

This PR create the same role for Sphinx which converts the given model Django path (`app_label.ModelName`) to the real path of the class in python (`app_label.models.ModelName`), allowing for the same docstring format to be used by both the Django admin documentation and Sphinx and still generate valid links for both.

For instance, one can now refer to the auth User model like this (`` :model:`auth.User` ``) and it will link to `django.contrib.auth.models.User` if such class was included in the documentation.