### PR TITLE
Use field.name for DeferredAttributes for Django 3.x, fixes #20

### DIFF
--- a/sphinxcontrib_django/docstrings.py
+++ b/sphinxcontrib_django/docstrings.py
@@ -241,7 +241,11 @@ def _improve_attribute_docs(obj, name, lines):
         # Get the field by importing the name.
         cls_path, field_name = name.rsplit(".", 1)
         model = import_string(cls_path)
-        field = model._meta.get_field(obj.field_name)
+        field = None
+        if django.VERSION >= (3, 0):
+           field = field = model._meta.get_field(obj.field.name)
+        else:
+            field = model._meta.get_field(obj.field_name)
 
         del lines[:]  # lines.clear() is Python 3 only
         lines.append("**Model field:** {label}".format(label=field.verbose_name))


### PR DESCRIPTION
This PR should fix #20

I did not found a way to force the usage of a DeferredAttribute and could therefore not write a test case.