### PR TITLE
use field_name for DeferredAttributes to be version agnostic

### DIFF
--- a/sphinxcontrib_django/docstrings.py
+++ b/sphinxcontrib_django/docstrings.py
@@ -241,10 +241,7 @@ def _improve_attribute_docs(obj, name, lines):
         # Get the field by importing the name.
         cls_path, field_name = name.rsplit(".", 1)
         model = import_string(cls_path)
-        if django.VERSION >= (3, 0):
-           field = model._meta.get_field(obj.field.name)
-        else:
-            field = model._meta.get_field(obj.field_name)
+        field = model._meta.get_field(field_name)
 
         del lines[:]  # lines.clear() is Python 3 only
         lines.append("**Model field:** {label}".format(label=field.verbose_name))

--- a/sphinxcontrib_django/tests/test_docstrings.py
+++ b/sphinxcontrib_django/tests/test_docstrings.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.db.models.query_utils import DeferredAttribute
 from django.test import SimpleTestCase
+from django.utils.module_loading import import_string
 from sphinx.application import Sphinx
 from sphinxcontrib_django import docstrings
 
@@ -105,9 +106,10 @@ class TestDocStrings(SimpleTestCase):
         lines = []
         simple_model_path = 'sphinxcontrib_django.tests.test_docstrings.SimpleModel'
         if django.VERSION < (3, 0):
-            obj = DeferredAttribute('dummy_field', simple_model_path)
+            obj = DeferredAttribute(field_name='dummy_field', model=simple_model_path)
         else:
-            obj = DeferredAttribute(simple_model_path)
+            model = import_string(simple_model_path)
+            obj = DeferredAttribute(field=model._meta.get_field('dummy_field'))
 
         docstrings._improve_attribute_docs(obj, '{}.dummy_field'.format(simple_model_path), lines)
         self.assertEqual(


### PR DESCRIPTION
As Django docs suggest, you can just use the field name of a model field to return the field instance.
https://docs.djangoproject.com/en/3.0/ref/models/meta/#django.db.models.options.Options.get_field

This makes the attribute doc retrieval for a DeferredAttribute easier as it is Django version agnostic.

Note: not quite sure whether I instantiated the DeferredAttribute correctly in the new test. Please have an eye on that.