### PR TITLE
Fix interference with other `autodoc-skip-member` signal handlers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* [ `#35 <https://github.com/edoburu/sphinxcontrib-django/issues/35>`_ ] Fix interference with other ``autodoc-skip-member`` signal handlers
+
+
 Version 2.1 (2023-03-01)
 ------------------------
 

--- a/sphinxcontrib_django/docstrings/__init__.py
+++ b/sphinxcontrib_django/docstrings/__init__.py
@@ -144,7 +144,7 @@ def autodoc_skip(app, what, name, obj, skip, options):
     if name in INCLUDE_MEMBERS:
         return False
 
-    return skip
+    return None
 
 
 def improve_docstring(app, what, name, obj, options, lines):


### PR DESCRIPTION
Fixes #35