### PR TITLE
Fix: Empty string enum rendering + Add configurable amount of choices to display

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 * [ `#39 <https://github.com/edoburu/sphinxcontrib-django/issues/39>`_ ] Fix table names of abstract models (`@insspb <https://github.com/insspb>`__)
+* [ `#41 <https://github.com/edoburu/sphinxcontrib-django/issues/41>`_ ] Fix rendering of iterable choices (`@insspb <https://github.com/insspb>`__)
 
 
 Version 2.3 (2023-04-12)

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,12 @@ Optionally, you can include the table names of your models in their docstrings w
     # Add abstract database tables names (only takes effect if django_show_db_tables is True)
     django_show_db_tables_abstract = True       # Boolean, default: False
 
+Optionally, you can extend amount of displayed choices in model fields with them:
+
+.. code-block:: python
+
+    # Integer amount of model field choices to show, default 10
+    django_choices_to_show = 10
 
 Advanced Usage
 --------------

--- a/sphinxcontrib_django/docstrings/__init__.py
+++ b/sphinxcontrib_django/docstrings/__init__.py
@@ -23,7 +23,7 @@ from sphinx.errors import ConfigError
 from .. import __version__
 from .attributes import improve_attribute_docstring
 from .classes import improve_class_docstring
-from .config import EXCLUDE_MEMBERS, INCLUDE_MEMBERS
+from .config import CHOICES_LIMIT, EXCLUDE_MEMBERS, INCLUDE_MEMBERS
 from .data import improve_data_docstring
 from .methods import improve_method_docstring
 
@@ -64,7 +64,8 @@ def setup(app):
     app.add_config_value("django_show_db_tables", False, True)
     # Set default of django_show_db_tables_abstract to False
     app.add_config_value("django_show_db_tables_abstract", False, True)
-
+    # Integer amount of model field choices to show
+    app.add_config_value("django_choices_to_show", CHOICES_LIMIT, True)
     # Setup Django after config is initialized
     app.connect("config-inited", setup_django)
 
@@ -111,7 +112,7 @@ def setup_django(app, config):
         raise ConfigError(
             "The module you specified in the configuration 'django_settings' in your"
             " conf.py cannot be imported. Make sure the module path is correct and the"
-            " source directoy is added to sys.path."
+            " source directory is added to sys.path."
         ) from e
     os.environ["DJANGO_SETTINGS_MODULE"] = config.django_settings
     django.setup()
@@ -182,7 +183,7 @@ def improve_docstring(app, what, name, obj, options, lines):
     if what == "class":
         improve_class_docstring(app, obj, lines)
     elif what == "attribute":
-        improve_attribute_docstring(obj, name, lines)
+        improve_attribute_docstring(app, obj, name, lines)
     elif what == "method":
         improve_method_docstring(name, lines)
     elif what == "data":

--- a/sphinxcontrib_django/docstrings/config.py
+++ b/sphinxcontrib_django/docstrings/config.py
@@ -22,5 +22,6 @@ EXCLUDE_MEMBERS = {
     "polymorphic_super_sub_accessors_replaced",
 }
 
-#: How many choices should be shown for model fields
+#: How many choices should be shown for model fields by default,
+#: used as default for ``django_choices_to_show`` option
 CHOICES_LIMIT = 10

--- a/tests/roots/test-docstrings/dummy_django_app/models.py
+++ b/tests/roots/test-docstrings/dummy_django_app/models.py
@@ -95,6 +95,9 @@ class ChoiceModel(models.Model):
     choice_limit_above = models.IntegerField(
         choices=[(i, i) for i in range(CHOICES_LIMIT + 2)]
     )
+    choice_with_empty = models.CharField(
+        choices=[("", "Empty"), ("Something", "Not empty")]
+    )
 
 
 class TaggedItem(models.Model):

--- a/tests/test_attribute_docstrings.py
+++ b/tests/test_attribute_docstrings.py
@@ -371,6 +371,64 @@ def test_choice_field_limit_above(app, do_autodoc):
     ]
 
 
+@pytest.mark.sphinx(
+    "html", testroot="docstrings", confoverrides={"django_choices_to_show": 15}
+)
+def test_choice_field_custom_limit(app, do_autodoc):
+    actual = do_autodoc(
+        app, "attribute", "dummy_django_app.models.ChoiceModel.choice_limit_above"
+    )
+    print(actual)
+    assert list(actual) == [
+        "",
+        ".. py:attribute:: ChoiceModel.choice_limit_above",
+        "   :module: dummy_django_app.models",
+        "",
+        "   Type: :class:`~django.db.models.IntegerField`",
+        "",
+        "   Choice limit above",
+        "",
+        "   Choices:",
+        "",
+        "   * ``0``",
+        "   * ``1``",
+        "   * ``2``",
+        "   * ``3``",
+        "   * ``4``",
+        "   * ``5``",
+        "   * ``6``",
+        "   * ``7``",
+        "   * ``8``",
+        "   * ``9``",
+        "   * ``10``",
+        "   * ``11``",
+        "",
+    ]
+
+
+@pytest.mark.sphinx("html", testroot="docstrings")
+def test_choice_field_empty(app, do_autodoc):
+    actual = do_autodoc(
+        app, "attribute", "dummy_django_app.models.ChoiceModel.choice_with_empty"
+    )
+    print(actual)
+    assert list(actual) == [
+        "",
+        ".. py:attribute:: ChoiceModel.choice_with_empty",
+        "   :module: dummy_django_app.models",
+        "",
+        "   Type: :class:`~django.db.models.CharField`",
+        "",
+        "   Choice with empty",
+        "",
+        "   Choices:",
+        "",
+        "   * ``''`` (Empty string)",
+        "   * ``Something``",
+        "",
+    ]
+
+
 if PHONENUMBER:
 
     @pytest.mark.sphinx("html", testroot="docstrings")


### PR DESCRIPTION
This PR will fix text choices rendering problem, from issue #41 and also it add completely clear approach to configure amount of choices to render (with sphinx option).

fixes #41

@timoludwig Please merge it