### PR TITLE
Drop support for sphinx < 3.4.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Drop support for sphinx < 3.4.0
+
+
 Version 2.4 (2023-07-02)
 ------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@
         "Topic :: Software Development :: Libraries :: Application Frameworks",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ]
-    dependencies = ["Django>=3.2", "Sphinx>=0.5", "pprintpp"]
+    dependencies = ["Django>=3.2", "Sphinx>=3.4.0", "pprintpp"]
     description = "Improve the Sphinx autodoc for Django classes."
     dynamic = ["version"]
     keywords = ["django", "docstrings", "extension", "sphinx"]


### PR DESCRIPTION
`sphinx.pycode.ModuleAnalyzer.parse()` was renamed to `sphinx.pycode.ModuleAnalyzer.analyze()` in https://github.com/sphinx-doc/sphinx/commit/8e29d57395f9cc964ac0de7e407c84bb45ec7906

Fixes #49