### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,14 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         django-version: ["django~=3.2", "django~=4.1", "django~=4.2"]
         optional-dependencies: ["optional-deps", "no-optional-deps"]
-        exclude:
-          - python-version: "3.7"
-            django-version: "django~=4.1"
-          - python-version: "3.7"
-            django-version: "django~=4.2"
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 
 * Drop support for sphinx < 3.4.0
 * [ `#45 <https://github.com/edoburu/sphinxcontrib-django/issues/45>`_ ] Fix rendering of inheritance diagrams
+* Drop support for Python 3.7
 
 
 Version 2.4 (2023-07-02)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -36,7 +35,7 @@
     license = { text = "Apache2 2.0 License" }
     name = "sphinxcontrib-django"
     readme = "README.rst"
-    requires-python = ">=3.7"
+    requires-python = ">=3.8"
 
     [project.urls]
         "Bug Tracker"   = "https://github.com/edoburu/sphinxcontrib-django/issues"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Drop support for Python 3.7, since it has reached its end of life