### PR TITLE
Update Python Intersphinx mapping

### DIFF
--- a/sphinxcontrib_django/roles.py
+++ b/sphinxcontrib_django/roles.py
@@ -84,7 +84,7 @@ def add_default_intersphinx_mappings(
     :param config: The Sphinx configuration
     """
     DEFAULT_INTERSPHINX_MAPPING = {
-        "python": ("https://docs.python.org/", None),
+        "python": ("https://docs.python.org/3/", None),
         "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
         "django": (
             "https://docs.djangoproject.com/en/stable/",


### PR DESCRIPTION
When building, I get these two warnings
```
intersphinx inventory has moved: https://docs.python.org/objects.inv -> https://docs.python.org/3/objects.inv
intersphinx inventory has moved: https://docs.djangoproject.com/en/stable/_objects/ -> https://docs.djangoproject.com/en/5.0/_objects/
```
The django one would be nice to fix, but obviously everyone has their own version of django pinned so (for now) there isn't much that can be done.
This PR updates the python mapping.