### PR TITLE
Dependency upgrades

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,11 +4,11 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
       - uses: psf/black@stable
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: chartboost/ruff-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run tests and generate coverage report
         run: coverage run
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,15 +4,20 @@ jobs:
   unittests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        django-version: ["django~=3.2", "django~=4.2", "django~=5.0"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        django-version: ["django~=4.2", "django~=5.2", "django~=6.0"]
         optional-dependencies: ["optional-deps", "no-optional-deps"]
         exclude:
-          - python-version: "3.8"
-            django-version: "django~=5.0"
-          - python-version: "3.9"
-            django-version: "django~=5.0"
+          - python-version: "3.13"
+            django-version: "django~=4.2"
+          - python-version: "3.14"
+            django-version: "django~=4.2"
+          - python-version: "3.10"
+            django-version: "django~=6.0"
+          - python-version: "3.11"
+            django-version: "django~=6.0"
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ sphinxcontrib-django
 
 This is a sphinx extension which improves the documentation of Django apps.
 
+**🚨 See** `Configuration`_ **for Sphinx 9+ compatibility 🚨**
 
 Features
 --------
@@ -74,6 +75,18 @@ Add the following to your Sphinx config file ``conf.py``:
 
     # Configure the path to the Django settings module
     django_settings = "myapp.settings"
+
+.. _sphinx_9_compat:
+
+**If you are using Sphinx >= 9 you must add the** `autodoc_use_legacy_class_based
+<https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_use_legacy_class_based>`_
+**setting:**
+
+.. code-block:: python
+
+    # Use legacy class-based autodoc implementation
+    autodoc_use_legacy_class_based = True
+
 
 Optionally, you can include the table names of your models in their docstrings with:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,3 +52,7 @@ html_logo = "images/django-sphinx-logo-white.png"
 html_favicon = "images/favicon.svg"
 # Do not include links to the documentation source (.rst files) in build
 html_show_sourcelink = False
+
+# On Sphinx > 9.0, toggle on the legacy class-based autodoc implementation for
+# compatibility
+autodoc_use_legacy_class_based = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,26 +10,26 @@
     classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
-        "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.2",
-        "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.2",
+        "Framework :: Django :: 6.0",
         "Framework :: Django",
         "Framework :: Sphinx :: Extension",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries :: Application Frameworks",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ]
-    dependencies = ["Django>=3.2", "Sphinx>=3.4.0", "pprintpp"]
+    dependencies = ["Django>=4.2", "Sphinx>=3.4.0", "pprintpp"]
     description = "Improve the Sphinx autodoc for Django classes."
     dynamic = ["version"]
     keywords = ["django", "docstrings", "extension", "sphinx"]
@@ -39,7 +39,7 @@
     ]
     name = "sphinxcontrib-django"
     readme = "README.rst"
-    requires-python = ">=3.8"
+    requires-python = ">=3.10"
 
     [project.urls]
         "Bug Tracker"   = "https://github.com/sphinx-doc/sphinxcontrib-django/issues"

--- a/sphinxcontrib_django/docstrings/patches.py
+++ b/sphinxcontrib_django/docstrings/patches.py
@@ -65,12 +65,6 @@ def patch_django_for_autodoc():
     # Support postgres fields if used
     if POSTGRES:
         DJANGO_MODULE_PATHS["django.contrib.postgres.forms"] = [postgres_forms.array]
-        # Support django.contrib.postgres.forms.JSONField in Django <= 3.2
-        if hasattr(postgres_forms, "jsonb"):
-            DJANGO_MODULE_PATHS["django.contrib.postgres.forms"].append(
-                postgres_forms.jsonb
-            )
-            postgres_forms.jsonb.__all__ = ("JSONString", "JSONField")
         DJANGO_MODULE_PATHS["django.contrib.postgres.fields"] = [postgres_fields.array]
         if hasattr(postgres_fields, "jsonb"):
             DJANGO_MODULE_PATHS["django.contrib.postgres.forms"].append(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,11 @@ https://github.com/sphinx-doc/sphinx/issues/7008), so this setup was created usi
 snippets and the existing test cases for the autodoc extension.
 """
 
+from pathlib import Path as path
 from unittest.mock import Mock
 
 import pytest
 from sphinx.ext.autodoc.directive import DocumenterBridge, process_documenter_options
-from sphinx.testing.path import path
 from sphinx.util.docutils import LoggingReporter
 
 pytest_plugins = "sphinx.testing.fixtures"
@@ -19,7 +19,7 @@ def rootdir():
     """
     Path to the root directory of the testing targets
     """
-    return path(__file__).parent.abspath() / "roots"
+    return path(__file__).parent.absolute() / "roots"
 
 
 @pytest.fixture(scope="function")

--- a/tests/roots/test-docstrings/conf.py
+++ b/tests/roots/test-docstrings/conf.py
@@ -14,6 +14,8 @@ extensions = [
 # Configure Django settings module
 django_settings = "dummy_django_app.settings"
 
+autodoc_use_legacy_class_based = True
+
 nitpicky = True
 
 

--- a/tests/test_class_docstrings.py
+++ b/tests/test_class_docstrings.py
@@ -1,4 +1,14 @@
 import pytest
+from django.conf import settings
+from django.db.models import AutoField
+
+
+def autofield():
+    return getattr(
+        settings,
+        "DEFAULT_AUTO_FIELD",
+        f"{AutoField.__module__}.{AutoField.__qualname__}",
+    )
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
@@ -11,7 +21,7 @@ def test_simple_model(app, do_autodoc):
         "   :module: dummy_django_app.models",
         "",
         "   :param id: Primary key: ID",
-        "   :type id: ~django.db.models.AutoField",
+        f"   :type id: ~{autofield()}",
         "   :param dummy_field: Very verbose name of dummy field. This should help you",
         "",
         "                       Docstring of char field",
@@ -100,7 +110,7 @@ def test_database_table(app, do_autodoc):
         "   **Database table:** ``dummy_django_app_simplemodel``",
         "",
         "   :param id: Primary key: ID",
-        "   :type id: ~django.db.models.AutoField",
+        f"   :type id: ~{autofield()}",
         "   :param dummy_field: Very verbose name of dummy field. This should help you",
         "",
         "                       Docstring of char field",
@@ -295,7 +305,7 @@ def test_file_model(app, do_autodoc):
         "   :module: dummy_django_app.models",
         "",
         "   :param id: Primary key: ID",
-        "   :type id: ~django.db.models.AutoField",
+        f"   :type id: ~{autofield()}",
         "   :param upload: Upload",
         "   :type upload: ~django.db.models.FileField",
         "",
@@ -325,7 +335,7 @@ def test_tagged_item(app, do_autodoc):
         "   :module: dummy_django_app.models",
         "",
         "   :param id: Primary key: ID",
-        "   :type id: ~django.db.models.AutoField",
+        f"   :type id: ~{autofield()}",
         "   :param tag: Tag",
         "   :type tag: ~django.db.models.SlugField",
         "   :param object_id: Object id",

--- a/tests/test_django_configured.py
+++ b/tests/test_django_configured.py
@@ -1,10 +1,17 @@
 import pytest
+from django.conf import settings
+from django.db.models import AutoField
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
 def test_django_configured(app, do_autodoc):
     actual = do_autodoc(app, "class", "dummy_django_app.models.MonkeyPatched")
     print(actual)
+    autofield = getattr(
+        settings,
+        "DEFAULT_AUTO_FIELD",
+        f"{AutoField.__module__}.{AutoField.__qualname__}",
+    )
     assert list(actual) == [
         "",
         ".. py:class:: MonkeyPatched(*args, **kwargs)",
@@ -13,7 +20,7 @@ def test_django_configured(app, do_autodoc):
         "   Monkeypatched docstring",
         "",
         "   :param id: Primary key: ID",
-        "   :type id: ~django.db.models.AutoField",
+        f"   :type id: ~{autofield}",
         "",
         "   .. inheritance-diagram:: dummy_django_app.models.MonkeyPatched",
         "",


### PR DESCRIPTION
### Short description

This PR upgrades the dependency test matrix, fixes tests and adds documentation regarding Sphinx 9+ compatibility.

### Proposed changes

1. Upgrades the CI matrix to include currently supported versions of python and django.
2. Sets minimum Django support to 4.2 and removes 3.2 specific patches
3. Fixes some tests that were broken on django > 5 due to change in default auto field
4. Adds documentation for Sphinx >= 9 and fixes the tests to work on Sphinx >= 9. See [this parameter](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_use_legacy_class_based) as pertains to the new auto-doc implementation.
5. Toggles fail fast off, so it is easier to see version combos that are failing.
6. Updates github actions and gets code cov uploads working again.

### Resolved issues

Closes #77 