### PR TITLE
Migrate versioning to setuptools-scm

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history so setuptools-scm can derive the version from tags
+          fetch-depth: 0
       - uses: actions/setup-python@v6
       - name: Install dependencies
         run: pip install build twine

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 * Add support for Python 3.12
+* Derive the package version from git tags via ``setuptools-scm``
 
 
 Version 2.5 (2023-09-26)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
     build-backend = "setuptools.build_meta"
-    requires      = ["setuptools"]
+    requires      = ["setuptools>=80", "setuptools-scm>=8"]
 
 [project]
     authors = [
@@ -57,8 +57,9 @@
         ]
         test = ["coverage", "pytest", "pytest-icdiff", "requests-mock"]
 
-[tool.setuptools.dynamic]
-    version = { attr = "sphinxcontrib_django.__version__" }
+[tool.setuptools_scm]
+    local_scheme   = "no-local-version"
+    version_scheme = "no-guess-dev"
 
 [tool.setuptools.packages.find]
     include = ["sphinxcontrib_django*"]

--- a/sphinxcontrib_django/__init__.py
+++ b/sphinxcontrib_django/__init__.py
@@ -4,9 +4,13 @@ This is a sphinx extension which improves the documentation of Django apps.
 
 from __future__ import annotations
 
-__version__ = "2.5"
-
+from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING
+
+try:
+    __version__ = version("sphinxcontrib-django")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0.dev0"
 
 from . import docstrings, roles
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Use setuptools-scm to dynamically derive the version from the git tag to avoid having to hard-code version number and to support dev-versions to be pushed to TestPyPI
