### PR TITLE
Migrate PyPI deployment to Trusted Publishing

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,41 +1,70 @@
 name: Deployment
+
 on: [push, pull_request]
+
 jobs:
-  has:
-    name: Check Secrets
-    runs-on: ubuntu-latest
-    steps:
-    - id: secrets
-      env:
-        test_pypi_token: ${{ secrets.TEST_PYPI_TOKEN }}
-        pypi_token: ${{ secrets.PYPI_TOKEN }}
-      if: ${{ env.test_pypi_token != '' && env.pypi_token != '' }}
-      run:
-        echo "::set-output name=secrets::1"
-    outputs:
-      secrets: ${{ steps.secrets.outputs.secrets }}
-  build-and-publish:
-    needs: has
+  build:
+    name: Build distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           # Full history so setuptools-scm can derive the version from tags
           fetch-depth: 0
+
       - uses: actions/setup-python@v6
+
       - name: Install dependencies
-        run: pip install build twine
+        run: pip install build
+
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
-      - name: Publish distribution 📦 to Test PyPI
-        if: ${{ needs.has.outputs.secrets }}
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-testpypi:
+    name: Publish to TestPyPI
+    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags')
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/sphinxcontrib-django
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: true
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sphinxcontrib-django
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
       - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Setup Trusted Publisher for PyPI as documented in https://docs.pypi.org/trusted-publishers/
