### PR TITLE
Repository health update

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<opensource@timo.brembeck.email>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/inclusion
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+Pull requests are always welcome!
+
+## Development setup
+
+Install all requirements of the development setup with the extras `dev`,
+`test`, `doc` and `optional`:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev,test,doc,optional]
+pre-commit install
+```
+
+## Tests
+
+Run the tests and generate the coverage report with:
+
+```bash
+coverage run
+coverage html
+```
+
+## Code style
+
+Formatting and linting are enforced by [black](https://github.com/psf/black)
+and [ruff](https://github.com/astral-sh/ruff) via pre-commit hooks, which run
+automatically on every commit after `pre-commit install`.
+
+## Documentation
+
+Build the documentation with:
+
+```bash
+cd docs
+make html
+```
+
+The documentation is automatically deployed to
+[Read the Docs](https://sphinxcontrib-django.readthedocs.io/).
+
+## Pull requests
+
+- Base your work on the `main` branch.
+- Add an entry to the `Unreleased` section of `CHANGES.rst` for user-facing
+  changes.
+- Reference related issues in the pull request description.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release of sphinxcontrib-django receives security updates.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities in public issues.
+
+Instead, report them privately via
+[GitHub security advisories](https://github.com/sphinx-doc/sphinxcontrib-django/security/advisories/new)
+or by email to <opensource@timo.brembeck.email>.
+
+You will receive a response as soon as possible. If the issue is confirmed, a
+fix will be released and the advisory published once users have a patched
+version available.

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v4.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,9 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       DJANGO: ${{ matrix.django-version }}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v7
       - name: Setup Python
-        uses: actions/setup-python@master
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.5.1
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.291
+    rev: v0.15.20
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.13"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,12 @@ Changelog
 Unreleased
 ----------
 
-* Add support for Python 3.12
+* Add support for Python 3.12, 3.13 and 3.14
+* Add support for Django 5.2 and 6.0 (`@bckohan <https://github.com/bckohan>`__)
+* Add compatibility with Sphinx 9, which requires setting ``autodoc_use_legacy_class_based = True`` (`@bckohan <https://github.com/bckohan>`__)
+* [ `#75 <https://github.com/sphinx-doc/sphinxcontrib-django/pull/75>`_ ] Add ``:django-admin:`` cross-reference role (`@bckohan <https://github.com/bckohan>`__)
 * Derive the package version from git tags via ``setuptools-scm``
+* Migrate PyPI releases to Trusted Publishing
 * [ `#73 <https://github.com/sphinx-doc/sphinxcontrib-django/issues/73>`_ ] Add support for callable choices (`@sevdog <https://github.com/sevdog>`__)
 * [ `#43 <https://github.com/sphinx-doc/sphinxcontrib-django/issues/43>`_ ] Fix crash on lazy string references in ``GenericRelation`` fields (`@ntouran <https://github.com/ntouran>`__)
 * Hide reverse accessor names disabled via ``related_name="+"`` instead of rendering a literal ``+``

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ from sphinxcontrib_django import __version__
 # -- Project information -----------------------------------------------------
 
 project = "sphinxcontrib-django"
-copyright = "2023"
+copyright = "2023 - %Y, Timo Brembeck"
 author = "Timo Brembeck"
 
 # The full version, including alpha/beta/rc tags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@
     testpaths  = ["tests"]
 
 [tool.ruff]
+  line-length = 99
+
+[tool.ruff.lint]
   select = [
     "F",
     "E",
@@ -96,4 +99,3 @@
   ignore = [
     "D1",   # Missing docstrings
   ]
-  line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@
         "Framework :: Django",
         "Framework :: Sphinx :: Extension",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -33,7 +32,7 @@
     description = "Improve the Sphinx autodoc for Django classes."
     dynamic = ["version"]
     keywords = ["django", "docstrings", "extension", "sphinx"]
-    license = { text = "Apache2 2.0 License" }
+    license = "Apache-2.0"
     maintainers = [
         { name = "Timo Brembeck", email = "opensource@timo.brembeck.email" },
     ]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Repository health update: refresh outdated tooling pins, fix broken package metadata and add missing community health files.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Bump the ruff pre-commit hook from v0.0.291 to v0.15.20, migrate the config to `[tool.ruff.lint]` and rename the hook id to `ruff-check`
- Bump the black pre-commit hook to 26.5.1 (no reformatting needed)
- Replace the archived `chartboost/ruff-action` with the official `astral-sh/ruff-action` in the linting workflow
- Pin `actions/checkout` and `actions/setup-python` to release tags in the tests workflow (floating `@master` refs are invisible to Dependabot)
- Declare the license as SPDX expression `Apache-2.0` (PEP 639), replacing the malformed free-text value `"Apache2 2.0 License"`, and drop the deprecated OSI classifier
- Update the Read the Docs build to ubuntu-24.04 and Python 3.13
- Fix the stale copyright year in the Sphinx config via the dynamic `%Y` placeholder
- Add a security policy, contributing guide and Contributor Covenant code of conduct
- Complete the unreleased changelog entries (Django 5.2/6.0, Python 3.13/3.14, Sphinx 9 compatibility, `:django-admin:` role, Trusted Publishing)

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

None