### PR TITLE
Drop support for Django 4.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,13 +7,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["django~=4.2", "django~=5.2", "django~=6.0"]
+        django-version: ["django~=5.2", "django~=6.0"]
         optional-dependencies: ["optional-deps", "no-optional-deps"]
         exclude:
-          - python-version: "3.13"
-            django-version: "django~=4.2"
-          - python-version: "3.14"
-            django-version: "django~=4.2"
           - python-version: "3.10"
             django-version: "django~=6.0"
           - python-version: "3.11"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 * Add support for Python 3.12, 3.13 and 3.14
+* Drop support for Django < 5.2 (Django 4.2 reached end of extended support in April 2026)
 * Add support for Django 5.2 and 6.0 (`@bckohan <https://github.com/bckohan>`__)
 * Add compatibility with Sphinx 9, which requires setting ``autodoc_use_legacy_class_based = True`` (`@bckohan <https://github.com/bckohan>`__)
 * [ `#75 <https://github.com/sphinx-doc/sphinxcontrib-django/pull/75>`_ ] Add ``:django-admin:`` cross-reference role (`@bckohan <https://github.com/bckohan>`__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@
     classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
-        "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.2",
         "Framework :: Django :: 6.0",
         "Framework :: Django",
@@ -28,7 +27,7 @@
         "Topic :: Software Development :: Libraries :: Application Frameworks",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ]
-    dependencies = ["Django>=4.2", "Sphinx>=3.4.0", "pprintpp"]
+    dependencies = ["Django>=5.2", "Sphinx>=3.4.0", "pprintpp"]
     description = "Improve the Sphinx autodoc for Django classes."
     dynamic = ["version"]
     keywords = ["django", "docstrings", "extension", "sphinx"]

--- a/tests/roots/test-docstrings/dummy_django_app/models.py
+++ b/tests/roots/test-docstrings/dummy_django_app/models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from django import VERSION
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -109,9 +108,8 @@ class ChoiceModel(models.Model):
     choice_with_empty = models.CharField(
         choices=[("", "Empty"), ("Something", "Not empty")]
     )
-    if VERSION >= (5, 0):
-        choice_with_callable = models.CharField(choices=callable_choices)
-        choice_with_callable_empty = models.CharField(choices=callable_choices_empty)
+    choice_with_callable = models.CharField(choices=callable_choices)
+    choice_with_callable_empty = models.CharField(choices=callable_choices_empty)
 
 
 class TaggedItem(models.Model):

--- a/tests/test_attribute_docstrings.py
+++ b/tests/test_attribute_docstrings.py
@@ -1,7 +1,4 @@
 import pytest
-from django import VERSION as DJANGO_VERSION
-
-SUPPORT_CALLABLE_CHOICES = DJANGO_VERSION >= (5, 0)
 
 try:
     from phonenumber_field.modelfields import PhoneNumberField  # noqa: F401
@@ -432,47 +429,46 @@ def test_choice_field_empty(app, do_autodoc):
     ]
 
 
-if SUPPORT_CALLABLE_CHOICES:
+@pytest.mark.sphinx("html", testroot="docstrings")
+def test_choice_field_callable(app, do_autodoc):
+    actual = do_autodoc(
+        app, "attribute", "dummy_django_app.models.ChoiceModel.choice_with_callable"
+    )
+    print(actual)
+    assert list(actual) == [
+        "",
+        ".. py:attribute:: ChoiceModel.choice_with_callable",
+        "   :module: dummy_django_app.models",
+        "",
+        "   Type: :class:`~django.db.models.CharField`",
+        "",
+        "   Choice with callable",
+        "",
+        "   Choices:",
+        "",
+        "   * ``Something``",
+        "",
+    ]
 
-    @pytest.mark.sphinx("html", testroot="docstrings")
-    def test_choice_field_callable(app, do_autodoc):
-        actual = do_autodoc(
-            app, "attribute", "dummy_django_app.models.ChoiceModel.choice_with_callable"
-        )
-        print(actual)
-        assert list(actual) == [
-            "",
-            ".. py:attribute:: ChoiceModel.choice_with_callable",
-            "   :module: dummy_django_app.models",
-            "",
-            "   Type: :class:`~django.db.models.CharField`",
-            "",
-            "   Choice with callable",
-            "",
-            "   Choices:",
-            "",
-            "   * ``Something``",
-            "",
-        ]
 
-    @pytest.mark.sphinx("html", testroot="docstrings")
-    def test_choice_field_callable_empty(app, do_autodoc):
-        actual = do_autodoc(
-            app,
-            "attribute",
-            "dummy_django_app.models.ChoiceModel.choice_with_callable_empty",
-        )
-        print(actual)
-        assert list(actual) == [
-            "",
-            ".. py:attribute:: ChoiceModel.choice_with_callable_empty",
-            "   :module: dummy_django_app.models",
-            "",
-            "   Type: :class:`~django.db.models.CharField`",
-            "",
-            "   Choice with callable empty",
-            "",
-        ]
+@pytest.mark.sphinx("html", testroot="docstrings")
+def test_choice_field_callable_empty(app, do_autodoc):
+    actual = do_autodoc(
+        app,
+        "attribute",
+        "dummy_django_app.models.ChoiceModel.choice_with_callable_empty",
+    )
+    print(actual)
+    assert list(actual) == [
+        "",
+        ".. py:attribute:: ChoiceModel.choice_with_callable_empty",
+        "   :module: dummy_django_app.models",
+        "",
+        "   Type: :class:`~django.db.models.CharField`",
+        "",
+        "   Choice with callable empty",
+        "",
+    ]
 
 
 if PHONENUMBER:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Drop support for Django 4.2, which reached the end of its extended support in April 2026. Django 5.2 LTS is now the oldest supported release.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Require `Django>=5.2` and remove the `Framework :: Django :: 4.2` trove classifier
- Remove Django 4.2 from the CI test matrix, including its Python version excludes
- Remove the now-dead `VERSION >= (5, 0)` gates around the callable-choices test model fields and tests
- Add a changelog entry

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

None
