### PR TITLE
Add type annotations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,9 +25,15 @@ coverage html
 
 ## Code style
 
-Formatting and linting are enforced by [black](https://github.com/psf/black)
-and [ruff](https://github.com/astral-sh/ruff) via pre-commit hooks, which run
+Formatting, linting and static type checking are enforced by
+[black](https://github.com/psf/black), [ruff](https://github.com/astral-sh/ruff)
+and [mypy](https://github.com/python/mypy) via pre-commit hooks, which run
 automatically on every commit after `pre-commit install`.
+
+Type annotations are required for all function signatures (enforced by ruff's
+`ANN` rules) and checked by mypy in strict mode. The autodoc target apps in
+`tests/roots/` are exempt, because their signatures are part of the expected
+test output.
 
 ## Documentation
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,3 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/ruff-action@v4.1.0
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+      - run: pip install pre-commit
+      - run: pre-commit run mypy --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,15 @@ repos:
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.3.0
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - django-stubs
+          - sphinx
+          - pprintpp
+          - pytest
+          - requests-mock
+          - types-docutils
+        pass_filenames: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Unreleased
 * Fix intersphinx mappings for ``django.http`` classes (``HttpRequest``, ``HttpResponse``, ...)
 * Fix the extension version not being reported to Sphinx due to a typo in the setup return value
 * Add type annotations throughout the code base and enforce them via ruff (`@WhyNotHugo <https://github.com/WhyNotHugo>`__)
+* Check the type annotations via mypy in strict mode
 
 
 Version 2.5 (2023-09-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Unreleased
 * [ `#87 <https://github.com/sphinx-doc/sphinxcontrib-django/issues/87>`_ ] List the URL paths under which a view function is reachable
 * Fix intersphinx mappings for ``django.http`` classes (``HttpRequest``, ``HttpResponse``, ...)
 * Fix the extension version not being reported to Sphinx due to a typo in the setup return value
+* Add type annotations throughout the code base and enforce them via ruff (`@WhyNotHugo <https://github.com/WhyNotHugo>`__)
 
 
 Version 2.5 (2023-09-26)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,6 +3,7 @@
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
+from __future__ import annotations
 
 from sphinxcontrib_django import __version__
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,23 @@
     minversion = "6.0"
     testpaths  = ["tests"]
 
+[tool.mypy]
+    exclude = "^tests/roots/"
+    files   = ["sphinxcontrib_django", "tests"]
+    strict  = true
+
+    [[tool.mypy.overrides]]
+        ignore_missing_imports = true
+        module = [
+            # Third-party packages which don't ship type information
+            "mptt.*",
+            "phonenumber_field.*",
+            "pprintpp",
+            # Autodoc target apps in tests/roots which are only importable at test runtime
+            "dummy_django_app.*",
+            "dummy_django_app2.*",
+        ]
+
 [tool.ruff]
   line-length = 99
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,11 +97,10 @@
   ]
   ignore = [
     "D1",   # Missing docstrings
-    "ANN101",  # Annotation for 'self'
   ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
   required-imports = ["from __future__ import annotations"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
   "tests/**/*.py" = ["ANN"] # TODO: tests are missing type annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,4 +103,6 @@
   required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
-  "tests/**/*.py" = ["ANN"] # TODO: tests are missing type annotations
+  # The signatures of these autodoc targets are part of the expected test output,
+  # so adding annotations here would change what the tests assert on.
+  "tests/roots/**/*.py" = ["ANN"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,12 @@
     # "D",
     "RET",
     "SIM",
+    "ANN",
   ]
   ignore = [
     "D1",   # Missing docstrings
+    "ANN101",  # Annotation for 'self'
   ]
+
+[tool.ruff.per-file-ignores]
+  "tests/**/*.py" = ["ANN"] # TODO: tests are missing type annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,5 +100,8 @@
     "ANN101",  # Annotation for 'self'
   ]
 
+[tool.ruff.isort]
+  required-imports = ["from __future__ import annotations"]
+
 [tool.ruff.per-file-ignores]
   "tests/**/*.py" = ["ANN"] # TODO: tests are missing type annotations

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 from setuptools import setup
 
 setup()

--- a/sphinxcontrib_django/__init__.py
+++ b/sphinxcontrib_django/__init__.py
@@ -16,9 +16,10 @@ from . import docstrings, roles
 
 if TYPE_CHECKING:
     import sphinx
+    from sphinx.util.typing import ExtensionMetadata
 
 
-def setup(app: sphinx.application.Sphinx) -> dict:
+def setup(app: sphinx.application.Sphinx) -> ExtensionMetadata:
     """
     Allow this module to be used as sphinx extension.
 

--- a/sphinxcontrib_django/docstrings/__init__.py
+++ b/sphinxcontrib_django/docstrings/__init__.py
@@ -36,9 +36,11 @@ from .views import improve_view_docstring
 
 if TYPE_CHECKING:
     import sphinx
+    from sphinx.ext.autodoc import Options
+    from sphinx.util.typing import ExtensionMetadata
 
 
-def setup(app: sphinx.application.Sphinx) -> dict:
+def setup(app: sphinx.application.Sphinx) -> ExtensionMetadata:
     """
     Allow this package to be used as Sphinx extension.
 
@@ -65,16 +67,16 @@ def setup(app: sphinx.application.Sphinx) -> dict:
 
     # Set default to environment variable to enable backwards compatibility
     app.add_config_value(
-        "django_settings", os.environ.get("DJANGO_SETTINGS_MODULE"), True
+        "django_settings", os.environ.get("DJANGO_SETTINGS_MODULE"), "env"
     )
 
     # Django models tables names configuration.
     # Set default of django_show_db_tables to False
-    app.add_config_value("django_show_db_tables", False, True)
+    app.add_config_value("django_show_db_tables", False, "env")
     # Set default of django_show_db_tables_abstract to False
-    app.add_config_value("django_show_db_tables_abstract", False, True)
+    app.add_config_value("django_show_db_tables_abstract", False, "env")
     # Integer amount of model field choices to show
-    app.add_config_value("django_choices_to_show", CHOICES_LIMIT, True)
+    app.add_config_value("django_choices_to_show", CHOICES_LIMIT, "env")
     # Setup Django after config is initialized
     app.connect("config-inited", setup_django)
 
@@ -133,8 +135,8 @@ def autodoc_skip(
     what: str,
     name: str,
     obj: object,
-    options: sphinx.ext.autodoc.Options,
-    lines: list[str],
+    skip: bool,
+    options: Options,
 ) -> bool | None:
     """
     Hook to tell autodoc to include or exclude certain fields (see :event:`autodoc-skip-member`).
@@ -146,6 +148,7 @@ def autodoc_skip(
     :param what: The parent type, ``class`` or ``module``
     :param name: The name of the child method/attribute.
     :param obj: The child value (e.g. a method, dict, or module reference)
+    :param skip: Whether autodoc would skip this member on its own
     :param options: The current autodoc settings.
     """
     if name in EXCLUDE_MEMBERS:
@@ -162,7 +165,7 @@ def improve_docstring(
     what: str,
     name: str,
     obj: object,
-    options: sphinx.ext.autodoc.Options,
+    options: Options,
     lines: list[str],
 ) -> list[str]:
     """
@@ -181,7 +184,7 @@ def improve_docstring(
                   handler can modify in place to change what Sphinx puts into the output.
     :return: The modified list of lines
     """
-    if what == "class":
+    if what == "class" and isinstance(obj, type):
         improve_class_docstring(app, obj, lines)
     elif what == "attribute":
         improve_attribute_docstring(app, obj, name, lines)
@@ -189,7 +192,7 @@ def improve_docstring(
         improve_method_docstring(name, lines)
     elif what == "data":
         improve_data_docstring(obj, lines)
-    elif what == "function":
+    elif what == "function" and callable(obj):
         improve_view_docstring(obj, lines)
 
     # Return the extended docstring

--- a/sphinxcontrib_django/docstrings/attributes.py
+++ b/sphinxcontrib_django/docstrings/attributes.py
@@ -4,6 +4,8 @@ This module contains all functions which are used to improve the documentation o
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from django.db import models
 from django.db.models.fields import related_descriptors
 from django.db.models.fields.files import FileDescriptor
@@ -15,7 +17,15 @@ from sphinx.util.docstrings import prepare_docstring
 
 from .field_utils import get_field_type, get_field_verbose_name
 
-FIELD_DESCRIPTORS = (FileDescriptor, related_descriptors.ForwardManyToOneDescriptor)
+if TYPE_CHECKING:
+    from typing import Any
+
+    from django.db.models.fields.reverse_related import ForeignObjectRel
+
+FIELD_DESCRIPTORS: tuple[type[Any], ...] = (
+    FileDescriptor,
+    related_descriptors.ForwardManyToOneDescriptor,
+)
 
 # Support for some common third party fields
 try:
@@ -93,7 +103,9 @@ def improve_attribute_docstring(
             lines.extend(docstring_lines[:-1])
 
 
-def get_field_details(app: Sphinx, field: models.Field) -> list[str]:
+def get_field_details(
+    app: Sphinx, field: models.Field[Any, Any] | ForeignObjectRel
+) -> list[str]:
     """
     This function returns the detail docstring of a model field.
     It includes the field type and the verbose name of the field.
@@ -110,7 +122,8 @@ def get_field_details(app: Sphinx, field: models.Field) -> list[str]:
         f"{get_field_verbose_name(field)}",
     ]
     # ensure lazy choices (e.g. callables) are evaluated
-    choices = list(field.choices) if getattr(field, "choices", None) else []
+    raw_choices = getattr(field, "choices", None)
+    choices = list(raw_choices) if raw_choices else []
     if choices:
         field_details.extend(["", "Choices:", ""])
         field_details.extend(

--- a/sphinxcontrib_django/docstrings/attributes.py
+++ b/sphinxcontrib_django/docstrings/attributes.py
@@ -10,6 +10,7 @@ from django.db.models.fields.files import FileDescriptor
 from django.db.models.manager import ManagerDescriptor
 from django.db.models.query_utils import DeferredAttribute
 from django.utils.module_loading import import_string
+from sphinx.application import Sphinx
 from sphinx.util.docstrings import prepare_docstring
 
 from .field_utils import get_field_type, get_field_verbose_name
@@ -25,23 +26,18 @@ except ImportError:
     PhoneNumberDescriptor = None
 
 
-def improve_attribute_docstring(app, attribute, name, lines):
+def improve_attribute_docstring(
+    app: Sphinx, attribute: object, name: str, lines: list[str]
+) -> None:
     """
     Improve the documentation of various model fields.
 
     This improves the navigation between related objects.
 
     :param app: The Sphinx application object
-    :type app: ~sphinx.application.Sphinx
-
     :param attribute: The instance of the object to document
-    :type attribute: object
-
     :param name: The full dotted path to the object
-    :type name: str
-
     :param lines: The docstring lines
-    :type lines: list [ str ]
     """
     # Save initial docstring lines to append them to the modified lines
     docstring_lines = lines.copy()
@@ -97,19 +93,14 @@ def improve_attribute_docstring(app, attribute, name, lines):
             lines.extend(docstring_lines[:-1])
 
 
-def get_field_details(app, field):
+def get_field_details(app: Sphinx, field: models.Field) -> list[str]:
     """
     This function returns the detail docstring of a model field.
     It includes the field type and the verbose name of the field.
 
     :param app: The Sphinx application object
-    :type app: ~sphinx.application.Sphinx
-
     :param field: The field
-    :type field: ~django.db.models.Field
-
     :return: The field details as list of strings
-    :rtype: list [ str ]
     """
     choices_limit = app.config.django_choices_to_show
 

--- a/sphinxcontrib_django/docstrings/classes.py
+++ b/sphinxcontrib_django/docstrings/classes.py
@@ -13,8 +13,12 @@ from sphinx.pycode import ModuleAnalyzer
 from .field_utils import get_field_type, get_field_verbose_name
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Any
+
     import django
     import sphinx
+    from django.db.models.fields.reverse_related import ForeignObjectRel
 
 
 def improve_class_docstring(
@@ -34,7 +38,9 @@ def improve_class_docstring(
 
 
 def improve_model_docstring(
-    app: sphinx.application.Sphinx, model: django.db.models.Model, lines: list[str]
+    app: sphinx.application.Sphinx,
+    model: type[django.db.models.Model],
+    lines: list[str],
 ) -> None:
     """
     Improve the documentation of a Django :class:`~django.db.models.Model` subclass.
@@ -42,7 +48,7 @@ def improve_model_docstring(
     This adds all model fields as parameters to the ``__init__()`` method.
 
     :param app: The Sphinx application object
-    :param model: The instance of the model to document
+    :param model: The class of the model to document
     :param lines: The docstring lines
     """
 
@@ -120,13 +126,15 @@ def improve_model_docstring(
 
 
 def add_db_table_name(
-    app: sphinx.application.Sphinx, model: django.db.models.Model, lines: list[str]
+    app: sphinx.application.Sphinx,
+    model: type[django.db.models.Model],
+    lines: list[str],
 ) -> None:
     """
     Format and add table name by extension configuration.
 
     :param app: The Sphinx application object
-    :param model: The instance of the model to document
+    :param model: The class of the model to document
     :param lines: The docstring lines
     """
     if model._meta.abstract and not app.config.django_show_db_tables_abstract:
@@ -138,7 +146,9 @@ def add_db_table_name(
 
 
 def add_model_parameters(
-    fields: list[django.db.models.Field], lines: list[str], field_docs: dict
+    fields: Sequence[django.db.models.Field[Any, Any] | ForeignObjectRel],
+    lines: list[str],
+    field_docs: dict[str, list[str]],
 ) -> None:
     """
     Add the given fields as model parameter with the ``:param:`` directive
@@ -163,17 +173,18 @@ def add_model_parameters(
         lines.append(f":type {field.name}: {get_field_type(field, include_role=False)}")
 
 
-def improve_form_docstring(form: django.forms.Form, lines: list[str]) -> None:
+def improve_form_docstring(form: type[django.forms.BaseForm], lines: list[str]) -> None:
     """
     Improve the documentation of a Django :class:`~django.forms.Form` class.
     This highlights the available fields in the form.
 
-    :param form: The form object
+    :param form: The class of the form to document
     :param lines: The list of existing docstring lines
     """
     lines.append("**Form fields:**")
     lines.append("")
-    for name, field in form.base_fields.items():
+    # ``base_fields`` is set by the form metaclass, so it's invisible on ``type[BaseForm]``
+    for name, field in form.base_fields.items():  # type: ignore[attr-defined]
         field_type = f"{field.__class__.__module__}.{field.__class__.__name__}"
         label = field.label or name.replace("_", " ").title()
         lines.append(f"* ``{name}``: {label} (:class:`~{field_type}`)")

--- a/sphinxcontrib_django/docstrings/config.py
+++ b/sphinxcontrib_django/docstrings/config.py
@@ -4,6 +4,8 @@ This module contains configuration of the members which should in-/excluded in s
 """
 
 #: Ensure that the __init__ method gets documented (also see :confval:`autoclass_content` setting)
+from __future__ import annotations
+
 INCLUDE_MEMBERS = {"__init__"}
 
 #: Members to hide.

--- a/sphinxcontrib_django/docstrings/data.py
+++ b/sphinxcontrib_django/docstrings/data.py
@@ -1,18 +1,17 @@
+from __future__ import annotations
+
 import io
 import sys
 
 from pprintpp import pprint as pp
 
 
-def improve_data_docstring(data, lines):
+def improve_data_docstring(data: object, lines: list[str]) -> None:
     """
     Improve the documentation of data by pretty-printing into in the docstring.
 
     :param data: The documented object
-    :type data: object
-
     :param lines: The lines of docstring lines
-    :type lines: list [ str ]
     """
     if isinstance(data, (list, tuple, dict, set)):
         # Redirect stdout to StringIO to catch print

--- a/sphinxcontrib_django/docstrings/field_utils.py
+++ b/sphinxcontrib_django/docstrings/field_utils.py
@@ -14,10 +14,17 @@ from django.db import models
 from django.utils.encoding import force_str
 
 if TYPE_CHECKING:
+    from typing import Any
+
     import django
+    from django.contrib.contenttypes.fields import GenericForeignKey
+    from django.db.models.fields.reverse_related import ForeignObjectRel
 
 
-def get_field_type(field: django.db.models.Field, include_role: bool = True) -> str:
+def get_field_type(
+    field: django.db.models.Field[Any, Any] | ForeignObjectRel,
+    include_role: bool = True,
+) -> str:
     """
     Get the type of a field including the correct intersphinx mappings.
 
@@ -49,7 +56,9 @@ def get_field_type(field: django.db.models.Field, include_role: bool = True) -> 
     return f"~{type(field).__module__}.{type(field).__name__}"
 
 
-def get_field_verbose_name(field: django.db.models.Field) -> str:
+def get_field_verbose_name(
+    field: django.db.models.Field[Any, Any] | ForeignObjectRel | GenericForeignKey,
+) -> str:
     """
     Get the verbose name of the field.
     If the field has a ``help_text``, it is also included.
@@ -76,14 +85,16 @@ def get_field_verbose_name(field: django.db.models.Field) -> str:
         )
         if isinstance(field, models.fields.reverse_related.OneToOneRel):
             # If a related name is given, use it, else use the verbose name of the remote model
-            related_name = related_name or field.remote_field.model._meta.verbose_name
+            related_name = related_name or force_str(
+                field.remote_field.model._meta.verbose_name
+            )
             # If field is a OneToOne field, use the prefix "The"
             verbose_name = f"The {related_name} of this {model._meta.verbose_name}"
         else:
             # This means field is an instance of ManyToOneRel or ManyToManyRel
             # If a related name is given, use it, else use the verbose name of the remote model
-            related_name = (
-                related_name or field.remote_field.model._meta.verbose_name_plural
+            related_name = related_name or force_str(
+                field.remote_field.model._meta.verbose_name_plural
             )
             # If field is a foreign key or a ManyToMany field, use the prefix "All"
             verbose_name = f"All {related_name} of this {model._meta.verbose_name}"
@@ -145,7 +156,7 @@ def get_field_verbose_name(field: django.db.models.Field) -> str:
 
 
 def get_model_from_string(
-    field: django.db.models.Field, model_string: str
+    field: django.db.models.Field[Any, Any], model_string: str
 ) -> type[django.db.models.Model]:
     """
     Get a model class from a string

--- a/sphinxcontrib_django/docstrings/methods.py
+++ b/sphinxcontrib_django/docstrings/methods.py
@@ -1,6 +1,7 @@
 """
 This module contains all functions which are used to improve the documentation of methods.
 """
+
 from __future__ import annotations
 
 import re

--- a/sphinxcontrib_django/docstrings/methods.py
+++ b/sphinxcontrib_django/docstrings/methods.py
@@ -1,6 +1,7 @@
 """
 This module contains all functions which are used to improve the documentation of methods.
 """
+from __future__ import annotations
 
 import re
 
@@ -9,7 +10,7 @@ RE_GET_NEXT_BY = re.compile(r"\.get_next_by_(?P<field>[a-zA-Z0-9_]+)$")
 RE_GET_PREVIOUS_BY = re.compile(r"\.get_previous_by_(?P<field>[a-zA-Z0-9_]+)$")
 
 
-def improve_method_docstring(name, lines):
+def improve_method_docstring(name: str, lines: list[str]) -> None:
     """
     Improve the documentation of methods automatically contributed to models by Django:
 
@@ -18,10 +19,7 @@ def improve_method_docstring(name, lines):
     * :meth:`~django.db.models.Model.get_previous_by_FOO`
 
     :param name: The full dotted path to the object.
-    :type name: str
-
     :param lines: The lines of docstring lines
-    :type lines: list [ str ]
     """
     if not lines:
         # Not doing obj.__module__ lookups to avoid performance issues.

--- a/sphinxcontrib_django/docstrings/patches.py
+++ b/sphinxcontrib_django/docstrings/patches.py
@@ -1,6 +1,7 @@
 """
 This module contains patches for Django to improve its interaction with Sphinx.
 """
+
 from __future__ import annotations
 
 import contextlib

--- a/sphinxcontrib_django/docstrings/patches.py
+++ b/sphinxcontrib_django/docstrings/patches.py
@@ -1,6 +1,7 @@
 """
 This module contains patches for Django to improve its interaction with Sphinx.
 """
+from __future__ import annotations
 
 import contextlib
 
@@ -25,7 +26,7 @@ except ModuleNotFoundError:
     MPTT = False
 
 
-def patch_django_for_autodoc():
+def patch_django_for_autodoc() -> None:
     """
     Fix the appearance of some classes in autodoc.
     E.g. the absolute path to the base model class is ``django.db.models.base.Model``, but its

--- a/sphinxcontrib_django/docstrings/patches.py
+++ b/sphinxcontrib_django/docstrings/patches.py
@@ -36,12 +36,12 @@ def patch_django_for_autodoc() -> None:
     This also avoids query evaluation.
     """
     # Fix Django's manager appearance
-    models.manager.ManagerDescriptor.__get__ = (
+    models.manager.ManagerDescriptor.__get__ = (  # type: ignore[method-assign]
         lambda self, *args, **kwargs: self.manager
     )
 
     # Stop Django from executing DB queries
-    models.QuerySet.__repr__ = lambda self: self.__class__.__name__
+    models.QuerySet.__repr__ = lambda self: self.__class__.__name__  # type: ignore[method-assign]
 
     # Fix django-mptt TreeManager in Django >=3.1
     if MPTT:
@@ -73,12 +73,16 @@ def patch_django_for_autodoc() -> None:
             DJANGO_MODULE_PATHS["django.contrib.postgres.forms"].append(
                 postgres_fields.jsonb
             )
-        postgres_forms.array.__all__ = ("SimpleArrayField", "SplitArrayField")
+        postgres_forms.array.__all__ = ("SimpleArrayField", "SplitArrayField")  # type: ignore[attr-defined]
 
     # Add __all__ where missing
-    models.base.__all__ = ("Model", "FilteredRelation")
-    models.fields.files.__all__ = ("FileField", "ImageField")
-    models.fields.related.__all__ = ("ForeignKey", "OneToOneField", "ManyToManyField")
+    models.base.__all__ = ("Model", "FilteredRelation")  # type: ignore[attr-defined]
+    models.fields.files.__all__ = ("FileField", "ImageField")  # type: ignore[attr-defined]
+    models.fields.related.__all__ = (  # type: ignore[attr-defined]
+        "ForeignKey",
+        "OneToOneField",
+        "ManyToManyField",
+    )
 
     # Set the __module__ to the parent module to make sure intersphinx mappings work as expected
     for parent_module_str, django_modules in DJANGO_MODULE_PATHS.items():

--- a/sphinxcontrib_django/docstrings/views.py
+++ b/sphinxcontrib_django/docstrings/views.py
@@ -11,9 +11,10 @@ from django.urls import get_resolver
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from typing import Any
 
 
-def improve_view_docstring(obj: Callable, lines: list[str]) -> None:
+def improve_view_docstring(obj: Callable[..., Any], lines: list[str]) -> None:
     """
     Add the URL paths under which a view function is reachable to its docstring.
 

--- a/sphinxcontrib_django/roles.py
+++ b/sphinxcontrib_django/roles.py
@@ -33,11 +33,12 @@ from . import __version__
 
 if TYPE_CHECKING:
     import sphinx
+    from sphinx.util.typing import ExtensionMetadata
 
 logger = logging.getLogger(__name__)
 
 
-def setup(app: sphinx.application.Sphinx) -> dict:
+def setup(app: sphinx.application.Sphinx) -> ExtensionMetadata:
     """
     Allow this module to be used as Sphinx extension.
 
@@ -98,5 +99,4 @@ def add_default_intersphinx_mappings(
         ),
     }
     if not config.intersphinx_mapping:
-        # TYPING: type hints are missing `.intersphinx_mapping` attribute.
-        config.intersphinx_mapping = DEFAULT_INTERSPHINX_MAPPING  # type: ignore[attr-defined ]
+        config.intersphinx_mapping = DEFAULT_INTERSPHINX_MAPPING

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,10 @@ def do_autodoc() -> Callable[..., StringList]:
     """
 
     def do_autodoc(
-        app: SphinxTestApp, objtype: str, name: str, options: dict | None = None
+        app: SphinxTestApp,
+        objtype: str,
+        name: str,
+        options: dict[str, Any] | None = None,
     ) -> StringList:
         if options is None:
             options = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,21 +3,31 @@ The recommended setup for testing sphinx extension is undocumented (see issue #7
 https://github.com/sphinx-doc/sphinx/issues/7008), so this setup was created using the given code
 snippets and the existing test cases for the autodoc extension.
 """
+
 from __future__ import annotations
 
 from pathlib import Path as path
-
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
 from sphinx.ext.autodoc.directive import DocumenterBridge, process_documenter_options
 from sphinx.util.docutils import LoggingReporter
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from typing import Any
+
+    from docutils.statemachine import StringList
+    from requests_mock import Mocker
+    from sphinx.testing.fixtures import SharedResult, _app_params
+    from sphinx.testing.util import SphinxTestApp
+
 pytest_plugins = "sphinx.testing.fixtures"
 
 
 @pytest.fixture(scope="session")
-def rootdir():
+def rootdir() -> path:
     """
     Path to the root directory of the testing targets
     """
@@ -25,7 +35,13 @@ def rootdir():
 
 
 @pytest.fixture(scope="function")
-def app(test_params, app_params, make_app, shared_result, requests_mock):
+def app(
+    test_params: dict[str, Any],
+    app_params: _app_params,
+    make_app: Callable[..., SphinxTestApp],
+    shared_result: SharedResult,
+    requests_mock: Mocker,
+) -> Iterator[SphinxTestApp]:
     """
     Overwrite sphinx.testing.fixtures.app to take the additional fixture requests_mock to fake
     intersphinx requests
@@ -36,14 +52,16 @@ def app(test_params, app_params, make_app, shared_result, requests_mock):
 
 
 @pytest.fixture(scope="function")
-def setup_app_with_different_config(app_params, make_app):
+def setup_app_with_different_config(
+    app_params: _app_params, make_app: Callable[..., SphinxTestApp]
+) -> Callable[..., SphinxTestApp]:
     """
     Simulate the setup of the sphinx app with a different config
     Return the function instead of the final app object to make sure exceptions occur inside the
     test and not inside the fixture
     """
 
-    def setup_app_with_different_config(**confoverrides):
+    def setup_app_with_different_config(**confoverrides: object) -> SphinxTestApp:
         args, kwargs = app_params
         kwargs["confoverrides"] = confoverrides
         return make_app(*args, **kwargs)
@@ -52,14 +70,16 @@ def setup_app_with_different_config(app_params, make_app):
 
 
 @pytest.fixture(scope="function")
-def do_autodoc():
+def do_autodoc() -> Callable[..., StringList]:
     """
     This function simulates the autodoc functionality.
 
     Taken from https://github.com/sphinx-doc/sphinx/blob/d635d94eebbca0ebb1a5402aa07ed58c0464c6d3/tests/test_ext_autodoc.py#L33-L45
     """
 
-    def do_autodoc(app, objtype, name, options=None):
+    def do_autodoc(
+        app: SphinxTestApp, objtype: str, name: str, options: dict | None = None
+    ) -> StringList:
         if options is None:
             options = {}
         app.env.temp_data.setdefault("docname", "index")  # set dummy docname

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,10 @@ The recommended setup for testing sphinx extension is undocumented (see issue #7
 https://github.com/sphinx-doc/sphinx/issues/7008), so this setup was created using the given code
 snippets and the existing test cases for the autodoc extension.
 """
+from __future__ import annotations
 
 from pathlib import Path as path
+
 from unittest.mock import Mock
 
 import pytest

--- a/tests/roots/test-docstrings/conf.py
+++ b/tests/roots/test-docstrings/conf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 

--- a/tests/roots/test-docstrings/conflicting_sphinx_extension.py
+++ b/tests/roots/test-docstrings/conflicting_sphinx_extension.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def setup(app):
     """
     Sphinx extension which also registers a "setting" directive

--- a/tests/roots/test-docstrings/dummy_django_app/settings.py
+++ b/tests/roots/test-docstrings/dummy_django_app/settings.py
@@ -1,6 +1,7 @@
 """
 Dummy Django settings file
 """
+from __future__ import annotations
 
 SECRET_KEY = "dummy-key"
 

--- a/tests/roots/test-docstrings/dummy_django_app/settings.py
+++ b/tests/roots/test-docstrings/dummy_django_app/settings.py
@@ -1,6 +1,7 @@
 """
 Dummy Django settings file
 """
+
 from __future__ import annotations
 
 SECRET_KEY = "dummy-key"

--- a/tests/roots/test-docstrings/dummy_django_app/urls.py
+++ b/tests/roots/test-docstrings/dummy_django_app/urls.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.urls import path
 
 from . import views

--- a/tests/roots/test-docstrings/dummy_django_app/views.py
+++ b/tests/roots/test-docstrings/dummy_django_app/views.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.http import HttpResponse
 
 

--- a/tests/roots/test-docstrings/dummy_django_app2/models.py
+++ b/tests/roots/test-docstrings/dummy_django_app2/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 

--- a/tests/test_attribute_docstrings.py
+++ b/tests/test_attribute_docstrings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 try:

--- a/tests/test_attribute_docstrings.py
+++ b/tests/test_attribute_docstrings.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from docutils.statemachine import StringList
+    from sphinx.testing.util import SphinxTestApp
+
 
 try:
     from phonenumber_field.modelfields import PhoneNumberField  # noqa: F401
@@ -12,7 +21,7 @@ except ModuleNotFoundError:
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_model_field(app, do_autodoc):
+def test_model_field(app: SphinxTestApp, do_autodoc: Callable[..., StringList]) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.SimpleModel.dummy_field"
     )
@@ -36,7 +45,7 @@ def test_model_field(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_foreignkey(app, do_autodoc):
+def test_foreignkey(app: SphinxTestApp, do_autodoc: Callable[..., StringList]) -> None:
     actual = do_autodoc(app, "attribute", "dummy_django_app.models.SimpleModel.file")
     print(actual)
     assert list(actual) == [
@@ -60,7 +69,9 @@ def test_foreignkey(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_foreignkey_id(app, do_autodoc):
+def test_foreignkey_id(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(app, "attribute", "dummy_django_app.models.SimpleModel.file_id")
     print(actual)
     assert list(actual) == [
@@ -77,7 +88,9 @@ def test_foreignkey_id(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_foreignkey_string(app, do_autodoc):
+def test_foreignkey_string(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(app, "attribute", "dummy_django_app.models.SimpleModel.file")
     print(actual)
     assert list(actual) == [
@@ -101,7 +114,9 @@ def test_foreignkey_string(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_foreignkey_string_abstract_model(app, do_autodoc):
+def test_foreignkey_string_abstract_model(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.AbstractModel.simple_model"
     )
@@ -122,7 +137,9 @@ def test_foreignkey_string_abstract_model(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_reverse_foreignkey(app, do_autodoc):
+def test_reverse_foreignkey(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.FileModel.simple_models"
     )
@@ -146,7 +163,9 @@ def test_reverse_foreignkey(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_manytomany_field(app, do_autodoc):
+def test_manytomany_field(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.SimpleModel.childrenB"
     )
@@ -176,7 +195,9 @@ def test_manytomany_field(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_reverse_manytomany_field(app, do_autodoc):
+def test_reverse_manytomany_field(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.ChildModelB.simple_models"
     )
@@ -200,7 +221,9 @@ def test_reverse_manytomany_field(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_reverse_onetoone_field(app, do_autodoc):
+def test_reverse_onetoone_field(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.ChildModelA.simple_model"
     )
@@ -224,7 +247,9 @@ def test_reverse_onetoone_field(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_generic_foreign_key(app, do_autodoc):
+def test_generic_foreign_key(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.TaggedItem.content_object"
     )
@@ -244,7 +269,9 @@ def test_generic_foreign_key(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_model_manager_fields(app, do_autodoc):
+def test_model_manager_fields(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.SimpleModel.custom_objects"
     )
@@ -264,7 +291,7 @@ def test_model_manager_fields(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_file_field(app, do_autodoc):
+def test_file_field(app: SphinxTestApp, do_autodoc: Callable[..., StringList]) -> None:
     actual = do_autodoc(app, "attribute", "dummy_django_app.models.FileModel.upload")
     print(actual)
     assert list(actual) == [
@@ -280,7 +307,9 @@ def test_file_field(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_choice_field(app, do_autodoc):
+def test_choice_field(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.ChoiceModel.choice_limit_below"
     )
@@ -310,7 +339,9 @@ def test_choice_field(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_choice_field_limit_exact(app, do_autodoc):
+def test_choice_field_limit_exact(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.ChoiceModel.choice_limit_exact"
     )
@@ -342,7 +373,9 @@ def test_choice_field_limit_exact(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_choice_field_limit_above(app, do_autodoc):
+def test_choice_field_limit_above(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.ChoiceModel.choice_limit_above"
     )
@@ -376,7 +409,9 @@ def test_choice_field_limit_above(app, do_autodoc):
 @pytest.mark.sphinx(
     "html", testroot="docstrings", confoverrides={"django_choices_to_show": 15}
 )
-def test_choice_field_custom_limit(app, do_autodoc):
+def test_choice_field_custom_limit(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.ChoiceModel.choice_limit_above"
     )
@@ -409,7 +444,9 @@ def test_choice_field_custom_limit(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_choice_field_empty(app, do_autodoc):
+def test_choice_field_empty(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.ChoiceModel.choice_with_empty"
     )
@@ -432,7 +469,9 @@ def test_choice_field_empty(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_choice_field_callable(app, do_autodoc):
+def test_choice_field_callable(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app.models.ChoiceModel.choice_with_callable"
     )
@@ -454,7 +493,9 @@ def test_choice_field_callable(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_choice_field_callable_empty(app, do_autodoc):
+def test_choice_field_callable_empty(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app,
         "attribute",
@@ -476,7 +517,9 @@ def test_choice_field_callable_empty(app, do_autodoc):
 if PHONENUMBER:
 
     @pytest.mark.sphinx("html", testroot="docstrings")
-    def test_phonenumber_field(app, do_autodoc):
+    def test_phonenumber_field(
+        app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+    ) -> None:
         actual = do_autodoc(
             app, "attribute", "dummy_django_app.models.PhoneNumberModel.phone_number"
         )
@@ -494,7 +537,9 @@ if PHONENUMBER:
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_generic_relation_field(app, do_autodoc):
+def test_generic_relation_field(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "attribute", "dummy_django_app2.models.GenericRelationModel.relation_field"
     )

--- a/tests/test_autodoc_skip.py
+++ b/tests/test_autodoc_skip.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/test_autodoc_skip.py
+++ b/tests/test_autodoc_skip.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from docutils.statemachine import StringList
+    from sphinx.testing.util import SphinxTestApp
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_exclude_members(app, do_autodoc):
+def test_exclude_members(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     options = {"members": None, "undoc-members": None}
     assert not any(
         "base_fields" in line
@@ -13,7 +23,9 @@ def test_exclude_members(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_include_members(app, do_autodoc):
+def test_include_members(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     options = {"members": None}
     assert any(
         "__init__" in line

--- a/tests/test_class_docstrings.py
+++ b/tests/test_class_docstrings.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from django.conf import settings
 from django.db.models import AutoField
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
-def autofield():
+    from docutils.statemachine import StringList
+    from sphinx.testing.util import SphinxTestApp
+
+
+def autofield() -> str:
     return getattr(
         settings,
         "DEFAULT_AUTO_FIELD",
@@ -14,7 +22,9 @@ def autofield():
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_simple_model(app, do_autodoc):
+def test_simple_model(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(app, "class", "dummy_django_app.models.SimpleModel")
     print(actual)
     assert list(actual) == [
@@ -101,7 +111,9 @@ def test_simple_model(app, do_autodoc):
 @pytest.mark.sphinx(
     "html", testroot="docstrings", confoverrides={"django_show_db_tables": True}
 )
-def test_database_table(app, do_autodoc):
+def test_database_table(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(app, "class", "dummy_django_app.models.SimpleModel")
     print(actual)
     assert list(actual) == [
@@ -188,7 +200,9 @@ def test_database_table(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_abstract_model(app, do_autodoc):
+def test_abstract_model(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(app, "class", "dummy_django_app.models.AbstractModel")
     print(actual)
     assert list(actual) == [
@@ -223,7 +237,9 @@ def test_abstract_model(app, do_autodoc):
 @pytest.mark.sphinx(
     "html", testroot="docstrings", confoverrides={"django_show_db_tables": True}
 )
-def test_abstract_model_with_tables_names_and_ignore_abstract(app, do_autodoc):
+def test_abstract_model_with_tables_names_and_ignore_abstract(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(app, "class", "dummy_django_app.models.AbstractModel")
     print(actual)
     assert list(actual) == [
@@ -263,7 +279,9 @@ def test_abstract_model_with_tables_names_and_ignore_abstract(app, do_autodoc):
         "django_show_db_tables_abstract": True,
     },
 )
-def test_abstract_model_with_tables_names_and_abstract_show(app, do_autodoc):
+def test_abstract_model_with_tables_names_and_abstract_show(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(app, "class", "dummy_django_app.models.AbstractModel")
     print(actual)
     assert list(actual) == [
@@ -298,7 +316,7 @@ def test_abstract_model_with_tables_names_and_abstract_show(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_file_model(app, do_autodoc):
+def test_file_model(app: SphinxTestApp, do_autodoc: Callable[..., StringList]) -> None:
     actual = do_autodoc(app, "class", "dummy_django_app.models.FileModel")
     print(actual)
     assert list(actual) == [
@@ -328,7 +346,7 @@ def test_file_model(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_tagged_item(app, do_autodoc):
+def test_tagged_item(app: SphinxTestApp, do_autodoc: Callable[..., StringList]) -> None:
     actual = do_autodoc(app, "class", "dummy_django_app.models.TaggedItem")
     print(actual)
     assert list(actual) == [
@@ -369,7 +387,7 @@ def test_tagged_item(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_form(app, do_autodoc):
+def test_form(app: SphinxTestApp, do_autodoc: Callable[..., StringList]) -> None:
     actual = do_autodoc(app, "class", "dummy_django_app.forms.SimpleForm")
     print(actual)
     assert list(actual) == [
@@ -396,7 +414,9 @@ def test_form(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_relation_model(app, do_autodoc):
+def test_relation_model(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(app, "class", "dummy_django_app2.models.GenericRelationModel")
     print(actual)
     assert list(actual) == [

--- a/tests/test_class_docstrings.py
+++ b/tests/test_class_docstrings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from django.conf import settings
 from django.db.models import AutoField

--- a/tests/test_data_docstrings.py
+++ b/tests/test_data_docstrings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/test_data_docstrings.py
+++ b/tests/test_data_docstrings.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from docutils.statemachine import StringList
+    from sphinx.testing.util import SphinxTestApp
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_data(app, do_autodoc):
+def test_data(app: SphinxTestApp, do_autodoc: Callable[..., StringList]) -> None:
     options = {"members": None}
     actual = do_autodoc(app, "module", "dummy_django_app.settings", options)
     print(actual)

--- a/tests/test_django_configured.py
+++ b/tests/test_django_configured.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from django.conf import settings
 from django.db.models import AutoField

--- a/tests/test_django_configured.py
+++ b/tests/test_django_configured.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from django.conf import settings
 from django.db.models import AutoField
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from docutils.statemachine import StringList
+    from sphinx.testing.util import SphinxTestApp
+
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_django_configured(app, do_autodoc):
+def test_django_configured(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(app, "class", "dummy_django_app.models.MonkeyPatched")
     print(actual)
     autofield = getattr(

--- a/tests/test_django_setup.py
+++ b/tests/test_django_setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from sphinx.errors import ConfigError
 

--- a/tests/test_django_setup.py
+++ b/tests/test_django_setup.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from sphinx.errors import ConfigError
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from sphinx.testing.util import SphinxTestApp
+
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_setup_with_missing_config(setup_app_with_different_config):
+def test_setup_with_missing_config(
+    setup_app_with_different_config: Callable[..., SphinxTestApp],
+) -> None:
     """
     Simulate the missing configuration of the Django settings
     """
@@ -14,7 +23,9 @@ def test_setup_with_missing_config(setup_app_with_different_config):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_setup_with_incorrect_config(setup_app_with_different_config):
+def test_setup_with_incorrect_config(
+    setup_app_with_different_config: Callable[..., SphinxTestApp],
+) -> None:
     """
     Simulate the incorrect configuration of the Django settings
     """

--- a/tests/test_field_utils.py
+++ b/tests/test_field_utils.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
 import copy
+from typing import TYPE_CHECKING
 
 import pytest
 
 from sphinxcontrib_django.docstrings.field_utils import get_field_verbose_name
 
+if TYPE_CHECKING:
+    from sphinx.testing.util import SphinxTestApp
+
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_reverse_rel_with_lazy_reference(app):
+def test_reverse_rel_with_lazy_reference(app: SphinxTestApp) -> None:
     # Simulate an unresolved lazy reference (see issue #43)
     from dummy_django_app2.models import GenericRelationModel
 
@@ -21,7 +27,7 @@ def test_reverse_rel_with_lazy_reference(app):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_one_to_one_rel_with_lazy_reference(app):
+def test_one_to_one_rel_with_lazy_reference(app: SphinxTestApp) -> None:
     from dummy_django_app.models import SimpleModel
 
     field = copy.copy(SimpleModel._meta.get_field("childA").remote_field)
@@ -33,7 +39,7 @@ def test_one_to_one_rel_with_lazy_reference(app):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_hidden_related_name_is_not_rendered(app):
+def test_hidden_related_name_is_not_rendered(app: SphinxTestApp) -> None:
     # related_name="+" disables the reverse accessor, so the literal "+" must
     # not appear in the docs
     from dummy_django_app2.models import GenericRelationModel

--- a/tests/test_method_docstrings.py
+++ b/tests/test_method_docstrings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/test_method_docstrings.py
+++ b/tests/test_method_docstrings.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from docutils.statemachine import StringList
+    from sphinx.testing.util import SphinxTestApp
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_model_method_display(app, do_autodoc):
+def test_model_method_display(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "method", "dummy_django_app.models.SimpleModel.get_dummy_field_display"
     )
@@ -23,7 +33,9 @@ def test_model_method_display(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_model_method_get_next_by(app, do_autodoc):
+def test_model_method_get_next_by(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "method", "dummy_django_app.models.SimpleModel.get_next_by_dummy_field"
     )
@@ -42,7 +54,9 @@ def test_model_method_get_next_by(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_model_method_get_previous_by(app, do_autodoc):
+def test_model_method_get_previous_by(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(
         app, "method", "dummy_django_app.models.SimpleModel.get_previous_by_dummy_field"
     )

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
+
+if TYPE_CHECKING:
+    from sphinx.testing.util import SphinxTestApp
 
 
 @pytest.mark.sphinx(
@@ -10,7 +15,9 @@ import pytest
         "extensions": ["conflicting_sphinx_extension", "sphinxcontrib_django"]
     },
 )
-def test_setup_with_conflicting_extension(app, caplog):
+def test_setup_with_conflicting_extension(
+    app: SphinxTestApp, caplog: pytest.LogCaptureFixture
+) -> None:
     setup_records = caplog.get_records("setup")
     assert len(setup_records) == 1
     assert setup_records[0].name == "sphinxcontrib_django.roles"

--- a/tests/test_view_docstrings.py
+++ b/tests/test_view_docstrings.py
@@ -1,13 +1,24 @@
+from __future__ import annotations
+
 import importlib
+from typing import TYPE_CHECKING
 
 import pytest
 from django.test import override_settings
 
 from sphinxcontrib_django.docstrings.views import improve_view_docstring
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from docutils.statemachine import StringList
+    from sphinx.testing.util import SphinxTestApp
+
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_view_url_paths(app, do_autodoc):
+def test_view_url_paths(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(app, "function", "dummy_django_app.views.simple_view")
     print(actual)
     assert list(actual) == [
@@ -26,7 +37,9 @@ def test_view_url_paths(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_function_without_url_unchanged(app, do_autodoc):
+def test_function_without_url_unchanged(
+    app: SphinxTestApp, do_autodoc: Callable[..., StringList]
+) -> None:
     actual = do_autodoc(app, "function", "dummy_django_app.views.not_a_view")
     print(actual)
     assert list(actual) == [
@@ -40,7 +53,7 @@ def test_function_without_url_unchanged(app, do_autodoc):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_no_root_urlconf_leaves_docstring_unchanged(app):
+def test_no_root_urlconf_leaves_docstring_unchanged(app: SphinxTestApp) -> None:
     simple_view = importlib.import_module("dummy_django_app.views").simple_view
     lines = ["A simple view function."]
     with override_settings(ROOT_URLCONF=None):
@@ -49,7 +62,7 @@ def test_no_root_urlconf_leaves_docstring_unchanged(app):
 
 
 @pytest.mark.sphinx("html", testroot="docstrings")
-def test_appends_blank_line_before_url_paths_section(app):
+def test_appends_blank_line_before_url_paths_section(app: SphinxTestApp) -> None:
     simple_view = importlib.import_module("dummy_django_app.views").simple_view
     lines = ["A simple view function."]
     improve_view_docstring(simple_view, lines)


### PR DESCRIPTION
### Short description

Add type annotations to all function signatures, enforce them via ruff's `ANN` (flake8-annotations) rules, and check them via mypy in strict mode, so new unannotated or wrongly annotated code fails CI. This revives the annotation work from #61.

### Provenance of the commits

The first three commits are taken from #61 by @WhyNotHugo (September 2023), which was closed without being merged after the discussion stalled on a Read the Docs build failure. They were rebased onto the current `main` with authorship preserved (`b36e6f2`, `a875275`, `cbba87e` on `WhyNotHugo:typing-o` → `d23bc5d`, `54ab381`, `0f7e1cc` here). The follow-up commits bring the branch up to date and complete it:

- `chore: adapt lint config and formatting to current ruff and black` — ruff has since moved `[tool.ruff.isort]` and `[tool.ruff.per-file-ignores]` under the `lint.` namespace and removed rule `ANN101`; formatting is re-aligned with the current black version.
- `test: add missing type annotations` — extends the annotation coverage to the test suite, which #61 deliberately left out.
- `docs: add changelog entry for type annotations`
- `chore: check type annotations via mypy in strict mode` — ruff only checks that annotations are *present*; mypy checks that they are *correct*, and immediately caught real defects (see below).

### Proposed changes

- Add type annotations to all function signatures in `sphinxcontrib_django` and in the test suite.
- Enforce annotations via ruff's `ANN` rules so CI fails on new unannotated code.
- Use lazy annotation evaluation (`from __future__ import annotations`, enforced via ruff isort's `required-imports`) so annotations don't incur runtime imports and forward references stay cheap.
- Check the annotations via mypy in strict mode (with `django-stubs`), both as a pre-commit hook and as a CI job running that hook. This uncovered genuine annotation defects: the model/form docstring processors receive classes, not instances (`type[Model]`/`type[BaseForm]`); the `autodoc-skip-member` handler receives the tentative skip decision as fifth argument, not the docstring lines; and `add_config_value` was passed the legacy alias `True` instead of the rebuild condition `"env"`.
- Exempt `tests/roots/**` from both `ANN` and mypy: these modules are autodoc *targets* whose signatures are part of the expected test output — annotating them would change what the tests assert on (e.g. `simple_view(request)` would render as `simple_view(request: HttpRequest) -> HttpResponse`).

### Resolved issues

Supersedes #61.