### PR TITLE
Reference Django models by their app label

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Unreleased
 * [ `#43 <https://github.com/sphinx-doc/sphinxcontrib-django/issues/43>`_ ] Fix crash on lazy string references in ``GenericRelation`` fields (`@ntouran <https://github.com/ntouran>`__)
 * Hide reverse accessor names disabled via ``related_name="+"`` instead of rendering a literal ``+``
 * [ `#87 <https://github.com/sphinx-doc/sphinxcontrib-django/issues/87>`_ ] List the URL paths under which a view function is reachable
+* [ `#90 <https://github.com/sphinx-doc/sphinxcontrib-django/issues/90>`_ ] Add ``:py:model:`` role to cross-reference Django models by their app label (`@jmfederico <https://github.com/jmfederico>`__)
 * Fix intersphinx mappings for ``django.http`` classes (``HttpRequest``, ``HttpResponse``, ...)
 * Fix the extension version not being reported to Sphinx due to a typo in the setup return value
 * Add type annotations throughout the code base and enforce them via ruff (`@WhyNotHugo <https://github.com/WhyNotHugo>`__)

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,8 @@ Improvements for the output of Sphinx's autodoc for Django classes:
 * Custom text roles to cross-reference the documentations of Django (``:setting:``,
   ``:templatetag:``, ``:templatefilter:``, ``:fieldlookup:``, ``:django-admin:``) and Sphinx (``:event:``,
   ``:confval:``)
+* Cross-reference Django models by their app label with ``:py:model:``, e.g.
+  ``:py:model:`auth.User``` — the same notation used by Django's admindocs
 
 
 Installation

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,13 @@ extensions = [
 nitpicky = True
 
 # A list of (type, target) tuples that should be ignored when :attr:`nitpicky` is ``True``
-nitpick_ignore = [("py:class", "sphinx.ext.autodoc.Options")]
+# (docutils provides no intersphinx inventory)
+nitpick_ignore = [
+    ("py:class", "sphinx.ext.autodoc.Options"),
+    ("py:class", "docutils.nodes.Element"),
+    ("py:class", "Element"),
+    ("py:class", "TextElement"),
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["templates"]

--- a/sphinxcontrib_django/roles.py
+++ b/sphinxcontrib_django/roles.py
@@ -27,15 +27,36 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from django.apps import apps
+from sphinx.domains.python import PyXRefRole
 from sphinx.errors import ExtensionError
 
 from . import __version__
 
 if TYPE_CHECKING:
+    import docutils
     import sphinx
     from sphinx.util.typing import ExtensionMetadata
 
 logger = logging.getLogger(__name__)
+
+
+class ModelRole(PyXRefRole):
+    """Expose Django models as roles for Sphinx."""
+
+    def process_link(
+        self,
+        env: sphinx.environment.BuildEnvironment,
+        refnode: docutils.nodes.Element,
+        has_explicit_title: bool,
+        title: str,
+        target: str,
+    ) -> tuple[str, str]:
+        """Get full python path to model."""
+        model = apps.get_model(target)
+        target = ".".join([model.__module__, model.__qualname__])
+
+        return super().process_link(env, refnode, has_explicit_title, title, target)
 
 
 def setup(app: sphinx.application.Sphinx) -> ExtensionMetadata:
@@ -70,6 +91,11 @@ def setup(app: sphinx.application.Sphinx) -> ExtensionMetadata:
             app.add_crossref_type(directivename=crossref_type, rolename=crossref_type)
         except ExtensionError as e:
             logger.warning("Unable to register cross-reference type: %s", e)
+
+    try:
+        app.add_role_to_domain("py", "class", ModelRole())
+    except ExtensionError as e:
+        logger.warning("Unable to register :py:model: role: %s", e)
 
     return {
         "version": __version__,

--- a/sphinxcontrib_django/roles.py
+++ b/sphinxcontrib_django/roles.py
@@ -15,6 +15,11 @@ Sphinx:
 * ``:event:``, e.g. ``:event:`autodoc-skip-member``` renders as :event:`autodoc-skip-member`
 * ``:confval:``, e.g. ``:confval:`extensions``` renders as :confval:`extensions`
 
+Additionally, this module adds the ``:py:model:`` role to cross-reference Django models by
+their ``app_label.ModelName`` notation known from :mod:`django.contrib.admindocs`, e.g.
+``:py:model:`auth.User``` links to the documentation of :class:`django.contrib.auth.models.User`
+if the model class is documented. Full import paths are supported as well.
+
 This module can also be used separately in ``conf.py``::
 
     extensions = [
@@ -42,7 +47,13 @@ logger = logging.getLogger(__name__)
 
 
 class ModelRole(PyXRefRole):
-    """Expose Django models as roles for Sphinx."""
+    """
+    Cross-reference role for Django models, registered as ``:py:model:``.
+
+    In addition to the full import path accepted by ``:py:class:``, it resolves the
+    ``app_label.ModelName`` notation of :mod:`django.contrib.admindocs` via the app registry,
+    so the same docstrings work in both the Django admin documentation and Sphinx.
+    """
 
     def process_link(
         self,
@@ -52,11 +63,22 @@ class ModelRole(PyXRefRole):
         title: str,
         target: str,
     ) -> tuple[str, str]:
-        """Get full python path to model."""
-        model = apps.get_model(target)
-        target = ".".join([model.__module__, model.__qualname__])
-
-        return super().process_link(env, refnode, has_explicit_title, title, target)
+        """Resolve the Django model label to the full python path of the model class."""
+        # Resolve the reference like a regular class cross-reference
+        refnode["reftype"] = "class"
+        title, target = super().process_link(
+            env, refnode, has_explicit_title, title, target
+        )
+        if target.count(".") == 1:
+            try:
+                model = apps.get_model(target)
+            except LookupError as e:
+                logger.warning(
+                    "Unable to resolve Django model reference %r: %s", target, e
+                )
+            else:
+                target = f"{model.__module__}.{model.__qualname__}"
+        return title, target
 
 
 def setup(app: sphinx.application.Sphinx) -> ExtensionMetadata:
@@ -65,7 +87,8 @@ def setup(app: sphinx.application.Sphinx) -> ExtensionMetadata:
 
     This is also called from the top-level :meth:`~sphinxcontrib_django.setup`.
 
-    It adds cross-reference types via :meth:`~sphinx.application.Sphinx.add_crossref_type`.
+    It adds cross-reference types via :meth:`~sphinx.application.Sphinx.add_crossref_type` and
+    the :class:`ModelRole` via :meth:`~sphinx.application.Sphinx.add_role_to_domain`.
 
     :param app: The Sphinx application object
     """
@@ -93,7 +116,7 @@ def setup(app: sphinx.application.Sphinx) -> ExtensionMetadata:
             logger.warning("Unable to register cross-reference type: %s", e)
 
     try:
-        app.add_role_to_domain("py", "class", ModelRole())
+        app.add_role_to_domain("py", "model", ModelRole())
     except ExtensionError as e:
         logger.warning("Unable to register :py:model: role: %s", e)
 

--- a/tests/roots/test-docstrings/conflicting_sphinx_extension.py
+++ b/tests/roots/test-docstrings/conflicting_sphinx_extension.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from sphinx.domains.python import PyXRefRole
+
 
 def setup(app):
     """
-    Sphinx extension which also registers a "setting" directive
+    Sphinx extension which also registers a "setting" directive and a "py:model" role
     """
     app.add_crossref_type(
         directivename="setting", rolename="setting", indextemplate="pair: %s; setting"
     )
+    app.add_role_to_domain("py", "model", PyXRefRole())

--- a/tests/roots/test-docstrings/index.rst
+++ b/tests/roots/test-docstrings/index.rst
@@ -1,0 +1,10 @@
+Dummy Django App
+================
+
+.. toctree::
+
+   models
+
+* Reference by Django model label: :py:model:`dummy_django_app.SimpleModel`
+* Reference by full import path: :py:model:`dummy_django_app.models.SimpleModel`
+* Reference to an unknown model: :py:model:`unknown_app.UnknownModel`

--- a/tests/roots/test-docstrings/models.rst
+++ b/tests/roots/test-docstrings/models.rst
@@ -1,0 +1,6 @@
+Models
+======
+
+.. automodule:: dummy_django_app.models
+   :members:
+   :show-inheritance:

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -19,6 +20,33 @@ def test_setup_with_conflicting_extension(
     app: SphinxTestApp, caplog: pytest.LogCaptureFixture
 ) -> None:
     setup_records = caplog.get_records("setup")
-    assert len(setup_records) == 1
-    assert setup_records[0].name == "sphinxcontrib_django.roles"
+    assert len(setup_records) == 2
+    assert all(record.name == "sphinxcontrib_django.roles" for record in setup_records)
     assert "Unable to register cross-reference type: " in setup_records[0].msg
+    assert "Unable to register :py:model: role: " in setup_records[1].msg
+
+
+@pytest.mark.sphinx("html", testroot="docstrings")
+def test_model_role(app: SphinxTestApp) -> None:
+    app.build()
+    html = (app.outdir / "index.html").read_text(encoding="utf-8")
+    links = re.findall(
+        r'<a class="reference internal"'
+        r' href="models\.html#dummy_django_app\.models\.SimpleModel"[^>]*>.*?</a>',
+        html,
+    )
+    assert any("dummy_django_app.SimpleModel</span>" in link for link in links)
+    assert any("dummy_django_app.models.SimpleModel</span>" in link for link in links)
+
+
+@pytest.mark.sphinx("html", testroot="docstrings", freshenv=True)
+def test_model_role_unknown_model(
+    app: SphinxTestApp, caplog: pytest.LogCaptureFixture
+) -> None:
+    app.build()
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "sphinxcontrib_django.roles"
+    ]
+    assert any("unknown_app.UnknownModel" in message for message in warnings)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Add a `:py:model:` role that cross-references Django models by their `app_label.ModelName` notation known from Django's admindocs, e.g. `` :py:model:`auth.User` ``. This supersedes the abandoned #19 by @jmfederico, whose original commit is kept for authorship.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add a `ModelRole` subclass of `PyXRefRole`, registered as `model` in the `py` domain: targets containing exactly one dot are resolved through the app registry (`apps.get_model`) to the model's full import path, then delegated to the standard class cross-reference — so intersphinx and the `~` shorthand work as usual.
- Full dotted import paths keep working unchanged; unknown app labels log a warning and fall through to normal resolution.
- Guard the registration with the same `ExtensionError` handling as the existing cross-reference types, so a conflicting extension only produces a warning.
- Add tests covering label resolution, full-path passthrough, the warning on unknown labels, and the registration conflict.
- Document the role in the README, the module docstring, and the changelog.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #90
