### PR TITLE
Add display names to field choices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Unreleased
 * Hide reverse accessor names disabled via ``related_name="+"`` instead of rendering a literal ``+``
 * [ `#87 <https://github.com/sphinx-doc/sphinxcontrib-django/issues/87>`_ ] List the URL paths under which a view function is reachable
 * [ `#90 <https://github.com/sphinx-doc/sphinxcontrib-django/issues/90>`_ ] Add ``:py:model:`` role to cross-reference Django models by their app label (`@jmfederico <https://github.com/jmfederico>`__)
+* [ `#63 <https://github.com/sphinx-doc/sphinxcontrib-django/issues/63>`_ ] Show the display names of field choices if they differ from the stored value
 * Fix intersphinx mappings for ``django.http`` classes (``HttpRequest``, ``HttpResponse``, ...)
 * Fix the extension version not being reported to Sphinx due to a typo in the setup return value
 * Add type annotations throughout the code base and enforce them via ruff (`@WhyNotHugo <https://github.com/WhyNotHugo>`__)

--- a/sphinxcontrib_django/docstrings/attributes.py
+++ b/sphinxcontrib_django/docstrings/attributes.py
@@ -127,17 +127,29 @@ def get_field_details(
     if choices:
         field_details.extend(["", "Choices:", ""])
         field_details.extend(
-            [
-                f"* ``{key}``" if key != "" else "* ``''`` (Empty string)"
-                for key, value in choices[:choices_limit]
-            ]
+            format_choice(key, value) for key, value in choices[:choices_limit]
         )
 
         # Check if list has been truncated
         if len(choices) > choices_limit:
             # If only one element has been truncated, just list it as well
             if len(choices) == choices_limit + 1:
-                field_details.append(f"* ``{choices[-1][0]}``")
+                field_details.append(format_choice(*choices[-1]))
             else:
                 field_details.append(f"* and {len(choices) - choices_limit} more")
     return field_details
+
+
+def format_choice(key: object, value: object) -> str:
+    """
+    Format a single field choice as a bullet point, including the human-readable
+    display name if it differs from the stored value.
+
+    :param key: The value stored in the database
+    :param value: The human-readable display name of the choice
+    :return: The formatted bullet point
+    """
+    bullet = f"* ``{key}``" if key != "" else "* ``''`` (Empty string)"
+    if str(value) != str(key):
+        bullet += f" — {value}"
+    return bullet

--- a/tests/test_attribute_docstrings.py
+++ b/tests/test_attribute_docstrings.py
@@ -462,8 +462,8 @@ def test_choice_field_empty(
         "",
         "   Choices:",
         "",
-        "   * ``''`` (Empty string)",
-        "   * ``Something``",
+        "   * ``''`` (Empty string) — Empty",
+        "   * ``Something`` — Not empty",
         "",
     ]
 
@@ -487,7 +487,7 @@ def test_choice_field_callable(
         "",
         "   Choices:",
         "",
-        "   * ``Something``",
+        "   * ``Something`` — Not empty",
         "",
     ]
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Show the human-readable display name of field choices in the generated documentation, e.g. `` `draft` — Draft (unpublished) `` instead of just `` `draft` ``.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Append the display name to each choice bullet point when it differs from the stored value — choices where both are equal (e.g. `(0, 0)`) keep rendering just the value, avoiding redundant output.
- Apply the same formatting to the single-overflow line shown when exactly one choice exceeds `django_choices_to_show`.
- Lazy translation strings used as display names are resolved during formatting.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #63
